### PR TITLE
Fix repeat on groups Microsoft/vscode#27784

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,14 +49,10 @@ export default function render(tree, field, formatter) {
 }
 
 function run(nodes, formatter, fieldsRenderer) {
-	return nodes.filter(notGroup).map(node => {
+	return nodes.map(node => {
 		const outNode = formatter(new OutputNode(node, fieldsRenderer));
 		return outNode ? outNode.toString(run(node.children, formatter, fieldsRenderer)) : '';
 	}).join('');
-}
-
-function notGroup(node) {
-    return !node.isGroup;
 }
 
 /**


### PR DESCRIPTION
See https://github.com/Microsoft/vscode/issues/27784

Abbreviations that have repeating groups are getting expanded with the group ignored.

Root cause:

- When there are no repeats on a group, the group node is removed from the tree by moving its children up. See https://github.com/emmetio/abbreviation/blob/v0.6.1/lib/parser.js#L47
- The output-renderer ignores all nodes that are a "group node". See https://github.com/emmetio/output-renderer/blob/v0.1.1/index.js#L52

This is why group nodes get ignored.

cc @sergeche 